### PR TITLE
Fix leading whitespace in tokens

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -4362,13 +4362,36 @@ const rules = {
 
   decimal_number: $ => choice(
     $.unsigned_number,
-    token(/([1-9][0-9_]*)?\s*'[sS]?[dD]\s*[0-9][0-9_]*/),
-    token(/([1-9][0-9_]*)?\s*'[sS]?[dD]\s*[xXzZ?][_]*/)
+    token(seq(
+        optional(/[1-9][0-9_]*/),
+        /'[sS]?[dD]/,
+        /[0-9][0-9_]*/
+    )),
+    token(seq(
+        optional(/[1-9][0-9_]*/),
+        /'[sS]?[dD]/,
+        /[xXzZ?][_]*/
+    ))
   ),
 
-  binary_number: $ => token(/([1-9][0-9_]*)?\s*'[sS]?[bB]\s*[01_xXzZ?]+/),
-  octal_number:  $ => token(/([1-9][0-9_]*)?\s*'[sS]?[oO]\s*[0-7_xXzZ?]+/),
-  hex_number:    $ => token(/([1-9][0-9_]*)?\s*'[sS]?[hH]\s*[0-9a-fA-F_xXzZ?]+/),
+  binary_number: $ =>
+    token(seq(
+        optional(/[1-9][0-9_]*/),
+        /'[sS]?[bB]/,
+        /[01_xXzZ?]+/
+    )),
+  octal_number:  $ =>
+    token(seq(
+        optional(/[1-9][0-9_]*/),
+        /'[sS]?[oO]/,
+        /[0-7_xXzZ?]+/
+    )),
+  hex_number:    $ =>
+    token(seq(
+        optional(/[1-9][0-9_]*/),
+        /'[sS]?[hH]/,
+        /[0-9a-fA-F_xXzZ?]+/
+    )),
 
   // NOTE: Embedded spaces are illegal.
   non_zero_unsigned_number: $ => token(/[1-9][0-9_]*/),


### PR DESCRIPTION
Previous to this change, the optional spaces in number regexes causes leading whitespace to be added to some parsed tokens.

The current tests are insufficient to catch this issue since they do not include the parsed text of the nodes.

Given the following sample code:

    function int f(a);
        a = 0;
    endfunction

* The variable 'a' parsed as "\n\<space>\<space>\<space>\<space>a" instead of "a"
* The unsigned number '0' parsed as "\<space>0" instead of "0"
* The keyword 'endfunction' parsed as "\nendfunction" instead of "endfunction"

I am not sure why this happens but I suspect the optional whitespace in the regexes has a negative interaction with the 'extras' field of the grammar.

This change fixes the problem by breaking up the number regexes into a sequence of regexes splitting on the optional whitespace.

The following shows a diff of the parse tree for the example code above before and after the fix.  The parse tree contains additional information beyond what the vanilla s-expressions provide.  Namely, it shows anonymous nodes and the text of leaf nodes.

```diff
--- before-fix  2019-09-23 23:41:17.270426500 -0700
+++ after-fix   2019-09-23 23:39:41.223142300 -0700
@@ -1,48 +1,45 @@
 source_file
     package_item
         function_declaration
             anonymous: 'function'
             function_body_declaration
                 function_data_type_or_implicit1
                     data_type_or_void
                         data_type
                             integer_atom_type
                                 anonymous: 'int'
                 function_identifier
                     function_identifier
                         simple_identifier: 'f'
                 anonymous: '('
                 tf_port_list
                     tf_port_item1
                         port_identifier
                             simple_identifier: 'a'
                 anonymous: ')'
                 anonymous: ';'
                 function_statement_or_null
                     function_statement
                         statement
                             statement_item
                                 blocking_assignment
                                     operator_assignment
                                         variable_lvalue
                                             identifier
-                                                simple_identifier: '
-    a'
+                                                simple_identifier: 'a'
                                         assignment_operator
                                             anonymous: '='
                                         expression
                                             primary
                                                 primary_literal
                                                     number
                                                         integral_number
                                                             decimal_number
-                                                                unsigned_number: ' 0'
+                                                                unsigned_number: '0'
                                 anonymous: ';'
-                anonymous: '
-endfunction'
+                anonymous: 'endfunction'
```