### PR TITLE
Add tests for constant_expression with varying parameter locations

### DIFF
--- a/corpus/assign.txt
+++ b/corpus/assign.txt
@@ -307,6 +307,77 @@ endmodule
   ))
 ))
 
+
+============================================
+assign - constant_range expression (parameter first)
+============================================
+
+module mod ();
+  assign a = b[Param+1:0];
+endmodule
+
+----
+
+(source_file (module_declaration
+  (module_header (module_keyword) (simple_identifier))
+  (module_nonansi_header (list_of_ports))
+  (module_or_generate_item (continuous_assign
+    (list_of_net_assignments (net_assignment
+      (net_lvalue (simple_identifier))
+      (expression (primary
+        (simple_identifier)
+        (select1
+          (constant_range
+            (constant_expression
+              (constant_expression (constant_primary (parameter_identifier (simple_identifier))))
+              (constant_expression
+                (constant_primary (primary_literal (integral_number (decimal_number (unsigned_number)))))
+              )
+            )
+            (constant_expression (constant_primary (primary_literal (integral_number (decimal_number (unsigned_number))))))
+          )
+        )
+      ))
+    ))
+  ))
+))
+
+
+============================================
+assign - constant_range expression (parameter first, LSB)
+============================================
+
+module mod ();
+  assign a = b[0:Param+1];
+endmodule
+
+----
+
+(source_file (module_declaration
+  (module_header (module_keyword) (simple_identifier))
+  (module_nonansi_header (list_of_ports))
+  (module_or_generate_item (continuous_assign
+    (list_of_net_assignments (net_assignment
+      (net_lvalue (simple_identifier))
+      (expression (primary
+        (simple_identifier)
+        (select1
+          (constant_range
+            (constant_expression (constant_primary (primary_literal (integral_number (decimal_number (unsigned_number))))))
+            (constant_expression
+              (constant_expression (constant_primary (parameter_identifier (simple_identifier))))
+              (constant_expression
+                (constant_primary (primary_literal (integral_number (decimal_number (unsigned_number)))))
+              )
+            )
+          )
+        )
+      ))
+    ))
+  ))
+))
+
+
 ============================================
 assign - precedence or, xor, and, eq
 ============================================


### PR DESCRIPTION
Issue #30 seems to already be fixed. I've added some tests to confirm that parameters are captured with different ordering/placement.