### PR TITLE
Grammar fix for system tf statements

### DIFF
--- a/corpus/tf.txt
+++ b/corpus/tf.txt
@@ -1,0 +1,146 @@
+============================================
+tf - assignment
+============================================
+
+module test;
+    initial begin
+        k = $random;
+    end
+endmodule
+
+----
+
+(source_file
+  (module_declaration
+    (module_header
+      (module_keyword)
+      (simple_identifier))
+    (module_or_generate_item
+      (initial_construct
+        (statement_or_null
+          (statement
+            (statement_item
+              (seq_block
+                (statement_or_null
+                  (statement
+                    (statement_item
+                      (blocking_assignment
+                        (operator_assignment
+                          (variable_lvalue
+                            (simple_identifier))
+                          (assignment_operator)
+                          (expression
+                            (primary
+                              (function_subroutine_call
+                                (subroutine_call
+                                  (system_tf_call
+                                    (system_tf_identifier)))))))))))))))))))
+
+============================================
+tf - statment
+============================================
+
+module test;
+    initial begin
+        $finish;
+    end
+endmodule
+
+----
+
+(source_file
+  (module_declaration
+    (module_header
+      (module_keyword)
+      (simple_identifier))
+    (module_or_generate_item
+      (initial_construct
+        (statement_or_null
+          (statement
+            (statement_item
+              (seq_block
+                (statement_or_null
+                  (statement
+                    (statement_item
+                      (system_tf_call
+                        (system_tf_identifier)))))))))))))
+
+============================================
+tf - print
+============================================
+
+module test;
+    initial begin
+        $print("%d, %d, %d", a, b, c);
+    end
+endmodule
+
+----
+
+(source_file
+  (module_declaration
+    (module_header
+      (module_keyword)
+      (simple_identifier))
+    (module_or_generate_item
+      (initial_construct
+        (statement_or_null
+          (statement
+            (statement_item
+              (seq_block
+                (statement_or_null
+                  (statement
+                    (statement_item
+                      (system_tf_call
+                        (system_tf_identifier)
+                        (list_of_arguments_parent
+                          (expression
+                            (primary
+                              (primary_literal
+                                (string_literal))))
+                          (expression
+                            (primary
+                              (simple_identifier)))
+                          (expression
+                            (primary
+                              (simple_identifier)))
+                          (expression
+                            (primary
+                              (simple_identifier))))))))))))))))
+
+============================================
+tf - inline
+============================================
+
+module test;
+    initial $monitor("%d, %d, %d", a, b, c);
+endmodule
+
+----
+
+(source_file
+  (module_declaration
+    (module_header
+      (module_keyword)
+      (simple_identifier))
+    (module_or_generate_item
+      (initial_construct
+        (statement_or_null
+          (statement
+            (statement_item
+              (system_tf_call
+                (system_tf_identifier)
+                (list_of_arguments_parent
+                  (expression
+                    (primary
+                      (primary_literal
+                        (string_literal))))
+                  (expression
+                    (primary
+                      (simple_identifier)))
+                  (expression
+                    (primary
+                      (simple_identifier)))
+                  (expression
+                    (primary
+                      (simple_identifier))))))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -2980,6 +2980,7 @@ const rules = {
     seq($.blocking_assignment, ';'),
     seq($.nonblocking_assignment, ';'),
     seq($.procedural_continuous_assignment, ';'),
+    seq($.system_tf_call, ';'),
     $.case_statement,
     $.conditional_statement,
     seq($.inc_or_dec_expression, ';'),


### PR DESCRIPTION
This PR contains grammar fixes for following tf statments with few testcases

```
initial $monitor("%d, %d", a, b);
````

```
initial begin
    $finish;
end
````