### PR TITLE
Add Swift Bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package-lock.json
 *.log
 uvm
 *.tar.gz
+.build/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterVerilog",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [
+        .library(name: "TreeSitterVerilog", targets: ["TreeSitterVerilog"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterVerilog",
+                path: ".",
+                exclude: [
+                    "binding.gyp",
+                    "bindings",
+                    "Cargo.toml",
+                    "corpus",
+                    "examples",
+                    "grammar.js",
+                    "LICENSE",
+                    "package.json",
+                    "README.md",
+                    "src/grammar.json",
+                    "src/node-types.json",
+                ],
+                sources: [
+                    "src/parser.c",
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
+)

--- a/bindings/swift/TreeSitterVerilog/verilog.h
+++ b/bindings/swift/TreeSitterVerilog/verilog.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_VERILOG_H_
+#define TREE_SITTER_VERILOG_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_verilog();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_VERILOG_H_


### PR DESCRIPTION
The Swift Package manager can build C and C++ sources and use headers to expose functions to Swift.

These additions and modifications allow the SPM to use the Verilog Tree Sitter and for use in Swift apps.